### PR TITLE
fix nav link static

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -11,7 +11,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
-SITEURL = ''
+SITEURL = 'https://shizuoka.pycon.jp/2020/'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'

--- a/pycon-mini-shizu-pelican-theme/templates/base.html
+++ b/pycon-mini-shizu-pelican-theme/templates/base.html
@@ -74,13 +74,13 @@
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                   {% for menuname_d1, content_d1 in content %}
-                  <a class="dropdown-item" href="/{{ content_d1 }}">{{ menuname_d1 }}</a>
+                  <a class="dropdown-item" href="{{ SITEURL }}/{{ content_d1 }}">{{ menuname_d1 }}</a>
                   {% endfor %}
                 </div>
               </li>
               {% else %}
                 <li class="active nav-item">
-                  <a class="nav-link js-scroll-trigger"  href="/{{ content }}">{{ menuname }}</a>
+                  <a class="nav-link js-scroll-trigger"  href="{{ SITEURL }}/{{ content }}">{{ menuname }}</a>
                 </li>
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
2020サイトのナビゲーションがトップドメイン向けになっていたので、サイトのurlを埋め込むような仕様に変更